### PR TITLE
octopus: skip make check

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -130,6 +130,11 @@ class Octopus(AutotoolsPackage, CudaPackage):
     # TODO: etsf-io, sparskit,
     # feast, libfm, pfft, isf, pnfft, poke
 
+
+    # Don't run the default command 'make check' for test
+    # as it takes too long to finish
+    build_time_test_callbacks = []
+
     def configure_args(self):
         spec = self.spec
         lapack = spec["lapack"].libs


### PR DESCRIPTION
This MR sets `build_time_test_callbacks = []` inorder to skip `make check` which takes a long time on octopus package.
Suggested from https://github.com/spack/spack/pull/38010#issuecomment-1577684446.
```shell
❯ spack install --test=root octopus
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/libpciaccess-0.17-o4ucj2e2c4nf7wu3wj3i2wndxtb6klnd
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/libiconv-1.17-sautitt5tfagsbp4c72svshcqycnmmgn
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/xz-5.4.1-b7pszt3srcszps3v7ncaxz37xkvea4bh
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/zlib-1.2.13-myqs6qhgz7dc65tqcfaalhn6ryu3cdoo
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/ncurses-6.4-qxxltqsdxoattttc5sx23q2dppmhliar
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/numactl-2.0.14-5p66kapsoai4lnwonwoewwdhoymgdhhw
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/bzip2-1.0.8-fbxbcci2aytembtuge5jnrormndbxi3v
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/zstd-1.5.5-bh7kcgqd56c4a4lkpq7iglehlidfcrl6
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/libxcrypt-4.4.33-5lv7iot7h7dwbc5ikvbwe7gtbx46r6pd
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/gsl-2.7.1-smdjs6u574fvjhcwogfredn3qpzomkln
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/libxc-6.1.0-ky4utjqwwljdtykjjfl7onlvg46xg62c
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/openblas-0.3.23-4gyn2hu62avpnazp3x7r6le5ehgia5vk
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/libxml2-2.10.3-vajbatkrikrqn5gxf4cdng7skkpzq2ec
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/openssl-1.1.1u-shfy7facvuytkyrhy5th6b7tgkfgwjsc
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/pigz-2.7-bun3sgcvw5d3jnsuyctyypnxiozqgguz
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/libedit-3.1-20210216-stslyt4vopugjhywqqsamxi2czzlfvox
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/hwloc-2.9.1-ul24lk7vby3assfzarhrxuveglq3dmkv
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/libevent-2.1.12-qvqcywfqdyywqdup2cqihisbcxlxy44h
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/tar-1.34-tbraya3ikp4g7dagsoex2cytmtzurfej
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/pmix-4.2.3-2bynbfqe3p54k4ksscabfet63yogwrrt
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/gettext-0.21.1-ahxd7a4s2lupezat5lram2m6tjsurl6i
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/krb5-1.20.1-72sozru42r5vs2p6zydd4mqylknwuvh3
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/openssh-9.3p1-phjdn765rrqpyu344muzyjndo5udxx4f
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/openmpi-4.1.5-kj4zhfgn7zniini7xje5z2uo3j4slzpz
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/fftw-3.3.10-kiri3gsnzam443jq7wssx2pomtol3o2i
==> Installing octopus-13.0-xijczvrpdho5berxehejot7dqrtb4s5x
==> No binary for octopus-13.0-xijczvrpdho5berxehejot7dqrtb4s5x found: installing from source
==> Using cached archive: /home/karnada/spackbox/tldspack/var/spack/cache/_source-cache/archive/b4/b4d0fd496c31a9c4aa4677360e631765049373131e61f396b00048235057aeb1.tar.gz
==> No patches needed for octopus
==> octopus: Executing phase: 'autoreconf'
==> octopus: Executing phase: 'configure'
==> octopus: Executing phase: 'build'
==> octopus: Executing phase: 'install'
==> octopus: Successfully installed octopus-13.0-xijczvrpdho5berxehejot7dqrtb4s5x
  Stage: 1.83s.  Autoreconf: 0.00s.  Configure: 16.58s.  Build: 4m 21.46s.  Install: 4.70s.  Post-install: 0.39s.  Total: 4m 45.14s
[+] /home/karnada/spackbox/tldspack/opt/spack/linux-fedora38-zen3/gcc-13.1.1/octopus-13.0-xijczvrpdho5berxehejot7dqrtb4s5x
❯ 

```